### PR TITLE
Add cache flushing to hotReload

### DIFF
--- a/plugin/TestEZ Companion.rbxmx
+++ b/plugin/TestEZ Companion.rbxmx
@@ -45,6 +45,8 @@ return extractUsefulKeys
         <string name="Source"><![CDATA[-- thank you einsteinK
 -- https://devforum.roblox.com/t/is-there-an-easier-way-to-reload-modules-that-have-been-required/61917/8?
 
+local hotReload = {}
+
 local function assertf(c, m, ...)
 	if c then
 		return
@@ -53,7 +55,12 @@ local function assertf(c, m, ...)
 end
 
 local loading, ERR = {}, {}
-local function customRequire(mod)
+
+function hotReload.flush()
+	loading = {}
+end
+
+function hotReload.require(mod)
 	local cached = loading[mod]
 	while cached == false do
 		wait()
@@ -68,7 +75,7 @@ local function customRequire(mod)
 	loading[mod] = false
 	local env = setmetatable({
 		script = mod,
-		require = customRequire,
+		require = hotReload.require,
 	}, { __index = getfenv() })
 	s, e = pcall(setfenv(s, env))
 	if not s then
@@ -79,7 +86,7 @@ local function customRequire(mod)
 	return e
 end
 
-return customRequire
+return hotReload
 ]]></string>
       </Properties>
     </Item>
@@ -103,8 +110,9 @@ local function log(level, ...)
 	end
 end
 
-local TestEZ = require(script.Parent:WaitForChild("testez")) -- keep in mind this has TestBootstrap modified
 local extractUsefulKeys = require(script.Parent:WaitForChild("extractUsefulKeys"))
+local hotReload = require(script.Parent.hotReload)
+local TestEZ = hotReload.require(script.Parent:WaitForChild("testez")) -- If we load it this way it doesn't need to be modified.
 
 local RunService = game:GetService("RunService")
 local HttpService = game:GetService("HttpService")
@@ -129,6 +137,7 @@ local function tryRunTestsAndReport(config)
 		roots[i] = unwrapPath(rootPath)
 	end
 
+	hotReload.flush()
 	TestEZ.TestBootstrap:run(roots, {
 		report = function(results)
 			debugPrint("reporting")
@@ -172,10 +181,6 @@ local function alive()
 		testsAreRunning = false
 	end
 end
-
-local module = Instance.new("ModuleScript")
-module.Parent = workspace
-module.Source = "print('cool')"
 
 -- seconds
 local POLLING_INTERVAL = 1
@@ -1102,14 +1107,12 @@ local function toStringPath(tablePath)
 	return stringPath
 end
 
-local hotReload = require(script.Parent.Parent.hotReload)
-
 function TestBootstrap:getModulesImpl(root, modules, current)
 	modules = modules or {}
 	current = current or root
 
 	if isSpecScript(current) then
-		local method = hotReload(current) -- modified for TestEZ Companion
+		local method = require(current)
 		local path = getPath(current, root)
 		local pathString = toStringPath(path)
 

--- a/plugin/src/hotReload.lua
+++ b/plugin/src/hotReload.lua
@@ -1,6 +1,8 @@
 -- thank you einsteinK
 -- https://devforum.roblox.com/t/is-there-an-easier-way-to-reload-modules-that-have-been-required/61917/8?
 
+local hotReload = {}
+
 local function assertf(c, m, ...)
 	if c then
 		return
@@ -9,7 +11,12 @@ local function assertf(c, m, ...)
 end
 
 local loading, ERR = {}, {}
-local function customRequire(mod)
+
+function hotReload.flush()
+	loading = {}
+end
+
+function hotReload.require(mod)
 	local cached = loading[mod]
 	while cached == false do
 		wait()
@@ -24,7 +31,7 @@ local function customRequire(mod)
 	loading[mod] = false
 	local env = setmetatable({
 		script = mod,
-		require = customRequire,
+		require = hotReload.require,
 	}, { __index = getfenv() })
 	s, e = pcall(setfenv(s, env))
 	if not s then
@@ -35,4 +42,4 @@ local function customRequire(mod)
 	return e
 end
 
-return customRequire
+return hotReload

--- a/plugin/src/plugin.server.lua
+++ b/plugin/src/plugin.server.lua
@@ -17,7 +17,7 @@ end
 
 local extractUsefulKeys = require(script.Parent:WaitForChild("extractUsefulKeys"))
 local hotReload = require(script.Parent.hotReload)
-local TestEZ = hotReload.require(script.Parent:WaitForChild("testez")) -- If we load it this way it doesn't need to be modified.
+local TestEZ = hotReload.require(script.Parent:WaitForChild("testez"))
 
 local RunService = game:GetService("RunService")
 local HttpService = game:GetService("HttpService")

--- a/plugin/src/plugin.server.lua
+++ b/plugin/src/plugin.server.lua
@@ -15,8 +15,9 @@ local function log(level, ...)
 	end
 end
 
-local TestEZ = require(script.Parent:WaitForChild("testez")) -- keep in mind this has TestBootstrap modified
 local extractUsefulKeys = require(script.Parent:WaitForChild("extractUsefulKeys"))
+local hotReload = require(script.Parent.hotReload)
+local TestEZ = hotReload.require(script.Parent:WaitForChild("testez")) -- If we load it this way it doesn't need to be modified.
 
 local RunService = game:GetService("RunService")
 local HttpService = game:GetService("HttpService")
@@ -41,6 +42,7 @@ local function tryRunTestsAndReport(config)
 		roots[i] = unwrapPath(rootPath)
 	end
 
+	hotReload.flush()
 	TestEZ.TestBootstrap:run(roots, {
 		report = function(results)
 			debugPrint("reporting")

--- a/plugin/src/testez/TestBootstrap.lua
+++ b/plugin/src/testez/TestBootstrap.lua
@@ -49,14 +49,12 @@ local function toStringPath(tablePath)
 	return stringPath
 end
 
-local hotReload = require(script.Parent.Parent.hotReload)
-
 function TestBootstrap:getModulesImpl(root, modules, current)
 	modules = modules or {}
 	current = current or root
 
 	if isSpecScript(current) then
-		local method = hotReload(current) -- modified for TestEZ Companion
+		local method = require(current)
 		local path = getPath(current, root)
 		local pathString = toStringPath(path)
 


### PR DESCRIPTION
Adds flushing to the hot reloading require module. Requires the all of TestEZ so we can flush before running new tests. Reverts TestBootstrap since it will no longer need to be aware of the special require with this method.

This ultimately resolves the hot reloading issue when there is more changed than the roots. In addition, this allows the use of a completely unmodified TestEZ. We could consider including it as a submodule or later as a package when a package manger becomes available (to allow easier TestEZ version selection).