### PR TITLE
Add chunk name when hot reloading

### DIFF
--- a/plugin/TestEZ Companion.rbxmx
+++ b/plugin/TestEZ Companion.rbxmx
@@ -63,7 +63,7 @@ local function customRequire(mod)
 	if cached then
 		return cached
 	end
-	local s, e = loadstring(mod.Source)
+	local s, e = loadstring(mod.Source, mod:GetFullName())
 	assertf(s, "Parsing error for %s: %s", mod:GetFullName(), tostring(e))
 	loading[mod] = false
 	local env = setmetatable({
@@ -172,10 +172,6 @@ local function alive()
 		testsAreRunning = false
 	end
 end
-
-local module = Instance.new("ModuleScript")
-module.Parent = workspace
-module.Source = "print('cool')"
 
 -- seconds
 local POLLING_INTERVAL = 1

--- a/plugin/src/hotReload.lua
+++ b/plugin/src/hotReload.lua
@@ -19,7 +19,7 @@ local function customRequire(mod)
 	if cached then
 		return cached
 	end
-	local s, e = loadstring(mod.Source)
+	local s, e = loadstring(mod.Source, mod:GetFullName())
 	assertf(s, "Parsing error for %s: %s", mod:GetFullName(), tostring(e))
 	loading[mod] = false
 	local env = setmetatable({


### PR DESCRIPTION
Adds the chunk name as the fully qualified path of the file being loaded.

This helps tremendously with debugging, otherwise loaded strings all appear as their full string in stack traces.