### PR TITLE
refactor(output): clear before running tests

### DIFF
--- a/plugin/src/plugin.server.lua
+++ b/plugin/src/plugin.server.lua
@@ -80,6 +80,7 @@ while true do
 			end
 		end
 
+		LogService:ClearOutput()
 		logServiceConnection = LogService.MessageOut:Connect(function(message, messageType)
 			pcall(HttpService.RequestAsync, HttpService, {
 				Url = BASE_URL .. "/logs",


### PR DESCRIPTION
`LogService:ClearOutput` was added recently in the last few releases. I wrote this via the web - so please let me know if this doesn't work.